### PR TITLE
Add smoother loading for album art #6

### DIFF
--- a/components/AlbumArt.tsx
+++ b/components/AlbumArt.tsx
@@ -16,6 +16,7 @@ const AlbumArt = ({ imageSourceUrl, handleImageError }: Props) => {
         src={imageSourceUrl || placeholderImagePath}
         alt="album art"
         layout="fill"
+        loading={"lazy"}
         onError={() => {
           handleImageError(placeholderImagePath);
         }}

--- a/components/AlbumArt.tsx
+++ b/components/AlbumArt.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import styles from "./AudioPlayer.module.css";
 
 const placeholderImagePath: string = "/img/cover-fallback.png";
 
@@ -11,6 +12,7 @@ const AlbumArt = ({ imageSourceUrl, handleImageError }: Props) => {
   return (
     <>
       <Image
+        className={styles.coverImage__albumImage}
         src={imageSourceUrl || placeholderImagePath}
         alt="album art"
         layout="fill"

--- a/components/AudioPlayer.module.css
+++ b/components/AudioPlayer.module.css
@@ -19,6 +19,9 @@
   0% {
     opacity:0;
   }
+  20% {
+    opacity: 0;
+  }
   100% {
     opacity:1;
   }
@@ -28,6 +31,9 @@
   0% {
     opacity:0;
   }
+  20% {
+    opacity: 0;
+  }
   100% {
     opacity:1;
   }
@@ -36,6 +42,9 @@
 @-webkit-keyframes fadeIn {
   0% {
     opacity:0;
+  }
+  20% {
+    opacity: 0;
   }
   100% {
     opacity:1;

--- a/components/AudioPlayer.module.css
+++ b/components/AudioPlayer.module.css
@@ -9,6 +9,39 @@
   background-color: #222;
 }
 
+.coverImage__albumImage {
+  animation: fadeIn ease-in 5s;
+  -webkit-animation: fadeIn ease-in 5s;
+  -moz-animation: fadeIn ease-in 5s;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity:0;
+  }
+  100% {
+    opacity:1;
+  }
+}
+
+@-moz-keyframes fadeIn {
+  0% {
+    opacity:0;
+  }
+  100% {
+    opacity:1;
+  }
+}
+
+@-webkit-keyframes fadeIn {
+  0% {
+    opacity:0;
+  }
+  100% {
+    opacity:1;
+  }
+}
+
 .loadingTextContainer {
   position: fixed;
   max-width: 50%;


### PR DESCRIPTION
Added smooth loading for the album art. I used [this link](https://blog.hubspot.com/website/css-fade-in) as a reference for the fading in. 