### PR TITLE
Add background fade for modals in Firefox 

### DIFF
--- a/components/Header/InfoModal.module.css
+++ b/components/Header/InfoModal.module.css
@@ -7,6 +7,12 @@
   animation: appear 200ms forwards;
 }
 
+@supports not (backdrop-filter: none) {
+  .container {
+    background: #000c;
+  }
+}
+
 @keyframes appear {
   from {
     opacity: 0;

--- a/components/Header/InfoModal.module.css
+++ b/components/Header/InfoModal.module.css
@@ -33,21 +33,6 @@
   cursor: pointer;
 }
 
-/* .button__close::before {
-  content: "x";
-  font-size: clamp(0.7rem, min(2vh, 4vw), 1.1rem);
-  color: #333;
-  font-weight: bold;
-  padding: 0.8em 1.5em;
-  position: fixed;
-  bottom: 10vh;
-  background: #fff;
-  border-radius: 10px;
-  left: 50%;
-  transform: translate(-50%, 0);
-  box-shadow: 5px 10px 30px -10px #0005;
-} */
-
 .box {
   width: min(75vw, 500px);
   padding: 2rem 2rem;

--- a/components/Header/ShareModal.module.css
+++ b/components/Header/ShareModal.module.css
@@ -7,6 +7,12 @@
   animation: appear 200ms forwards;
 }
 
+@supports not (backdrop-filter: none) {
+  .container {
+    background: #000c;
+  }
+}
+
 @keyframes appear {
   from {
     opacity: 0;


### PR DESCRIPTION
Added alternative option to fade-out background in browsers not supporting backdrop-filter (mainly Firefox).

Fixes issue #29 